### PR TITLE
Updating package.json to newest bittorrent-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/feross/instant.io/issues"
   },
   "dependencies": {
-    "bittorrent-client": "^0.7.3",
+    "bittorrent-client": "^0.8.0",
     "block-stream": "0.0.7",
     "compression": "^1.0.9",
     "concat-stream": "^1.4.6",


### PR DESCRIPTION
There is a breaking change between 0.7.3 to 0.8.0 apparently, due to the previous name of 'bittorrent-discovery', now 'torrent-discovery':

```

nicolamozilla:instant.io mozilla$ npm install .
...
npm ERR! 404 Not Found
npm ERR! 404 
npm ERR! 404 'bittorrent-discovery' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 It was specified as a dependency of 'bittorrent-client'
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, or http url, or git url.

npm ERR! System Darwin 13.3.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "bittorrent-client"
npm ERR! cwd /Users/mozilla/Proj/gits/instant.io
npm ERR! node -v v0.10.29
npm ERR! npm -v 1.5.0-alpha-1
npm ERR! code E404
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/mozilla/Proj/gits/instant.io/npm-debug.log
npm ERR! not ok code 0
```
