### PR TITLE
Fix standard linting

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,3 +1,5 @@
+/* global URL */
+
 var createTorrent = require('create-torrent')
 var debug = require('debug')('instant.io')
 var dragDrop = require('drag-drop')


### PR DESCRIPTION
Fixes the following linting errors:

```
standard: Use JavaScript Standard Style (https://standardjs.com)
  /Users/linus/coding/standard/tmp/instant.io/client/index.js:261:25: 'URL' is not defined. (no-undef)
  /Users/linus/coding/standard/tmp/instant.io/client/index.js:267:17: 'URL' is not defined. (no-undef)
```