### PR TITLE
Upgrade insecure request

### DIFF
--- a/server/views/layout.pug
+++ b/server/views/layout.pug
@@ -3,6 +3,7 @@ html(lang='en')
   head
     title= title
     meta(charset='utf-8')
+    meta(http-equiv='Content-Security-Policy', content='upgrade-insecure-requests')
     meta(name='viewport', content='width=device-width, initial-scale=1')
     link(rel='search', href='/opensearch.xml', title='Instant.io', type='application/opensearchdescription+xml')
     link(rel='stylesheet', href='/main.css', charset='utf-8')


### PR DESCRIPTION
You enforce https on your site so no content can be loaded from http. this will make all WebSeed url's to https if not already

Relevant to: https://github.com/webtorrent/webtorrent/issues/1471