### PR TITLE
textContent should be used for unsafe html

### DIFF
--- a/client/util.js
+++ b/client/util.js
@@ -7,8 +7,8 @@ exports.log = function log (item, unsafe) {
   logHeading.style.display = 'block'
 
   var p = document.createElement('p')
-  if (unsafe) p.innerHTML = item
-  else p.textContent = item
+  if (unsafe) p.textContent = item
+  else p.innerHTML = item
   logElem.appendChild(p)
   return p
 }


### PR DESCRIPTION
[X] Bug fix

Fixed what looks to basically be a typo from the last commit to this file. Obviously it's **safe** content which you want to use innerHTML for...
