### PR TITLE
Use unsafeLog for links in seed summary. Move info hash to it's own line.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -181,8 +181,8 @@ function onTorrent (torrent) {
     util.unsafeLog('&nbsp;&nbsp;- ' + escapeHtml(file.name) + ' (' + escapeHtml(prettierBytes(file.length)) + ')')
   })
 
-  util.log(
-    'Torrent info hash: ' + escapeHtml(torrent.infoHash) + ' ' +
+  util.log('Torrent info hash: ' + torrent.infoHash)
+  util.unsafeLog(
     '<a href="/#' + escapeHtml(torrent.infoHash) + '" onclick="prompt(\'Share this link with anyone you want to download this torrent:\', this.href);return false;">[Share link]</a> ' +
     '<a href="' + escapeHtml(torrent.magnetURI) + '" target="_blank">[Magnet URI]</a> ' +
     '<a href="' + escapeHtml(torrent.torrentFileBlobURL) + '" target="_blank" download="' + escapeHtml(torrentFileName) + '">[Download .torrent]</a>'


### PR DESCRIPTION
Replaces #218 

The links at the end of a seed summary were being escaped by `util.log`. I think it was an oversight that `util.unsafeLog` wasn't used.

I also felt like the torrent info hash belonged on it's own line, which actually allowed me to use util.log, which feels much better.