### PR TITLE
Change the Copyright 2020 to Copyright 2021.

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -26,4 +26,4 @@ block body
         button(type='submit') Download
 
     footer
-      p: small Powered by <a href="http://webtorrent.io" target="_blank">WebTorrent</a>. 100% open source &amp; free software. Works in Chrome, Firefox, and Opera. Source code available on <a href="https://github.com/webtorrent/instant.io" target="_blank">GitHub</a>. © 2020 WebTorrent, LLC.
+      p: small Powered by <a href="http://webtorrent.io" target="_blank">WebTorrent</a>. 100% open source &amp; free software. Works in Chrome, Firefox, and Opera. Source code available on <a href="https://github.com/webtorrent/instant.io" target="_blank">GitHub</a>. © 2021 WebTorrent, LLC.


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain: The Copyright 2020 was obviously outdated, and it needed to be updated.

**What changes did you make? (Give an overview)**: Changed the text "2020" to "2021".

**Which issue (if any) does this pull request address?**: Wrong copyright year.

**Is there anything you'd like reviewers to focus on?**: No