### PR TITLE
Adds Overridable Trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Copy [`secret/index-sample.js`](https://github.com/webtorrent/instant.io/blob/ma
 
 To start the server, run `npm run build && npm start`. That should be it!
 
+#### Testing a bittorrent-tracker
+
+The `bittorrent-tracker` can be set to localhost if needed. When using the `bittorrent-tracker` make sure the websocket server is
+enabled. Note that Instant.io filters out the http servers in the default trackers list.
+
 ## Tips
 
 1. Create a shareable link by adding a torrent infohash or magnet link to the end

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -14,6 +14,10 @@ block body
     section
       h1 Start sharing
       p
+        | Torrent Trackers:
+        | #{ ' ' }
+        input(type='text', id='trackers' style='width: 100%;')
+      p
         | Drag-and-drop files to begin seeding. Or choose a file:
         | #{ ' ' }
         input(type='file', name='upload', multiple)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

Note: Fixed bug of udp trackers slipping in despite explicit filter due to implicit list concatenations from global variables. The result is a change in the generated magnetURI where the udp trackers have now been removed. The website continues to operate ok. Preserving previous behavior involves modifying global state in the call stack, specifically the `globalThis.WEBTORRENT_ANNOUNCE` variable. This cl ends the writing of this variable by setting the announce list explicitly in the call.

However, that's a lot of changes. I understand if the team will pass on this feature.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

![image](https://user-images.githubusercontent.com/6856673/177614852-eac5606e-6002-464f-9cce-9b4567c260c8.png)


Allows overridable trackers such as the all important localhost tracker during development. This is represented as a text box which is auto populated by the default trackers. The user can change these trackers urls to their own. For example I'll change mine to `ws://localhost:8000`

**Which issue (if any) does this pull request address?**

The ability to run instant.io in a development setting using a local debug server.

**Is there anything you'd like reviewers to focus on?**

Testing was performed manually:
  * A local dev version of instant.io website was used WITHOUT using the new override feature. The result was the file uploaded had the normal trackers attached onto the magnetURI.
  * The local dev version was used WITH using localserver `ws://localhost:8000` spawned by executing `bittorrent-tracker`, it too was verified to work correctly and transfer the file.

Update: Manually verified that this causes a bug, due to this line of code:
https://github.com/webtorrent/create-torrent/blob/1c62c651a99efe3394b81366b19b8ae13c64c3cc/index.js#L300

Local dev instant.io generated this magnetURI:
`magnet:?xt=urn:btih:a79afb88341ce1e3b30167889991ea03310d73ff&dn=battery_swap.mp4&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com`

instant.io version generated this magnetURI:
`magnet:?xt=urn:btih:a79afb88341ce1e3b30167889991ea03310d73ff&dn=battery_swap.mp4&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337`


Keep in mind the local dev version of instant.io did not have any turn servers enabled.